### PR TITLE
feat: introduce ColumnarSeries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "band_demo"
+version = "0.33.0"
+dependencies = [
+ "eframe",
+ "egui_plot",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +736,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "columnar"
+version = "0.33.0"
+dependencies = [
+ "eframe",
+ "egui_plot",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +865,22 @@ dependencies = [
  "eframe",
  "egui_plot",
  "env_logger",
+]
+
+[[package]]
+name = "custom_tooltip"
+version = "0.33.0"
+dependencies = [
+ "eframe",
+ "egui_plot",
+]
+
+[[package]]
+name = "default_tooltip"
+version = "0.33.0"
+dependencies = [
+ "eframe",
+ "egui_plot",
 ]
 
 [[package]]

--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -3,7 +3,7 @@
 //! Each push to `main` re-deploys the demo.
 
 #![warn(clippy::all, rust_2018_idioms)]
-
+#![allow(deprecated)]
 mod app;
 mod plot_demo;
 

--- a/egui_plot/src/items/columnar_series.rs
+++ b/egui_plot/src/items/columnar_series.rs
@@ -1,0 +1,199 @@
+use core::fmt;
+use core::ops::{Bound, RangeBounds};
+
+use crate::transform::PlotBounds;
+
+/// A zero-copy Series of `(x, y)`.
+///
+/// This is the canonical way to pass data into plotting items without packing
+/// into `PlotPoint` vectors. Multiple series can share the same `xs` slice.
+#[derive(Copy, Clone)]
+pub struct ColumnarSeries<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+}
+
+impl<'a> ColumnarSeries<'a> {
+    /// Construct a columnar series from borrowed `xs` and `ys`.
+    ///
+    /// # Panics
+    /// Panics if `xs.len() != ys.len()`. If you want a version that
+    /// *truncates* to the shorter length instead, see [`Self::new_truncating`].
+    #[inline]
+    pub fn new(xs: &'a [f64], ys: &'a [f64]) -> Self {
+        assert!(
+            xs.len() == ys.len(),
+            "ColumnarSeries::new: xs and ys must have equal length (got {} vs {})",
+            xs.len(),
+            ys.len()
+        );
+        Self { xs, ys }
+    }
+
+    /// Construct a series by **truncating to the shorter** of `xs` and `ys`.
+    ///
+    /// This never panics. If the lengths differ, the longer one is sliced down.
+    #[inline]
+    pub fn new_truncating(xs: &'a [f64], ys: &'a [f64]) -> Self {
+        let n = xs.len().min(ys.len());
+        Self {
+            xs: &xs[..n],
+            ys: &ys[..n],
+        }
+    }
+
+    /// An always-valid empty series.
+    pub const EMPTY: ColumnarSeries<'static> = ColumnarSeries { xs: &[], ys: &[] };
+
+    /// Borrow the X slice.
+    #[inline]
+    pub fn xs(&self) -> &'a [f64] {
+        self.xs
+    }
+
+    /// Borrow the Y slice.
+    #[inline]
+    pub fn ys(&self) -> &'a [f64] {
+        self.ys
+    }
+
+    /// Number of samples.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.xs.len()
+    }
+
+    /// Is the series empty?
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.xs.is_empty()
+    }
+
+    /// Get the `(x, y)` at `index`, if in-bounds.
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<(f64, f64)> {
+        if index < self.len() {
+            Some((self.xs[index], self.ys[index]))
+        } else {
+            None
+        }
+    }
+
+    /// Return an iterator over `(x, y)` pairs (by value).
+    #[inline]
+    pub fn iter(&self) -> Iter<'a> {
+        Iter {
+            xs: self.xs,
+            ys: self.ys,
+            i: 0,
+        }
+    }
+
+    /// Return a **subseries** sliced by element **index** range.
+    ///
+    /// Accepts any `RangeBounds<usize>`; `Bound::Excluded` and `Bound::Included`
+    /// are honored; the result is clamped to `[0, len()]`. Empty ranges return
+    /// [`ColumnarSeries::EMPTY`].
+    pub fn slice<R>(&self, range: R) -> Self
+    where
+        R: RangeBounds<usize>,
+    {
+        let len = self.len();
+
+        let start = match range.start_bound() {
+            Bound::Unbounded => 0,
+            Bound::Included(&i) => i,
+            Bound::Excluded(&i) => i.saturating_add(1),
+        }
+        .min(len);
+
+        let end = match range.end_bound() {
+            Bound::Unbounded => len,
+            Bound::Included(&i) => i.saturating_add(1),
+            Bound::Excluded(&i) => i,
+        }
+        .min(len);
+
+        if end <= start {
+            ColumnarSeries::EMPTY
+        } else {
+            ColumnarSeries {
+                xs: &self.xs[start..end],
+                ys: &self.ys[start..end],
+            }
+        }
+    }
+
+    /// Estimate numeric bounds over all finite points in the series.
+    ///
+    /// Non-finite values (`NaN`, `±∞`) are **ignored**. If no finite values
+    /// are found, returns `PlotBounds::NOTHING`.
+    pub fn bounds(&self) -> PlotBounds {
+        let mut b = PlotBounds::NOTHING;
+
+        // Fast path for contiguous slices.
+        for i in 0..self.len() {
+            let x = self.xs[i];
+            let y = self.ys[i];
+            if x.is_finite() {
+                b.extend_with_x(x);
+            }
+            if y.is_finite() {
+                b.extend_with_y(y);
+            }
+        }
+        b
+    }
+}
+
+/// Iterator over `(x, y)` pairs in a [`ColumnarSeries`].
+pub struct Iter<'a> {
+    xs: &'a [f64],
+    ys: &'a [f64],
+    i: usize,
+}
+
+impl Iterator for Iter<'_> {
+    type Item = (f64, f64);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i >= self.xs.len() {
+            return None;
+        }
+        let i = self.i;
+        self.i += 1;
+        Some((self.xs[i], self.ys[i]))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self.xs.len().saturating_sub(self.i);
+        (n, Some(n))
+    }
+}
+
+impl ExactSizeIterator for Iter<'_> {}
+
+impl fmt::Debug for ColumnarSeries<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ColumnarSeries")
+            .field("len", &self.len())
+            .finish()
+    }
+}
+
+impl PartialEq for ColumnarSeries<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.xs == other.xs && self.ys == other.ys
+    }
+}
+
+impl Eq for ColumnarSeries<'_> {}
+
+impl<'a> From<(&'a [f64], &'a [f64])> for ColumnarSeries<'a> {
+    #[inline]
+    fn from(tup: (&'a [f64], &'a [f64])) -> Self {
+        Self::new(tup.0, tup.1)
+    }
+}

--- a/egui_plot/src/items/mod.rs
+++ b/egui_plot/src/items/mod.rs
@@ -21,6 +21,7 @@ pub use crate::items::tooltip::TooltipOptions;
 pub use band::Band;
 pub use bar::Bar;
 pub use box_elem::{BoxElem, BoxSpread};
+pub use columnar_series::ColumnarSeries;
 pub use values::{
     ClosestElem, LineStyle, MarkerShape, Orientation, PlotGeometry, PlotPoint, PlotPoints,
 };
@@ -28,6 +29,7 @@ pub use values::{
 mod band;
 mod bar;
 mod box_elem;
+mod columnar_series;
 mod rect_elem;
 mod tooltip;
 mod values;
@@ -156,6 +158,20 @@ pub trait PlotItem {
             PlotGeometry::Rects => {
                 panic!("If the PlotItem is made of rects, it should implement find_closest()")
             }
+            PlotGeometry::PointsXY { xs, ys } => {
+                let n = xs.len().min(ys.len());
+                (0..n)
+                    .map(|index| {
+                        let value = PlotPoint {
+                            x: xs[index],
+                            y: ys[index],
+                        };
+                        let pos = transform.position_from_point(&value);
+                        let dist_sq = point.distance_sq(pos);
+                        ClosestElem { index, dist_sq }
+                    })
+                    .min_by_key(|e| e.dist_sq.ord())
+            }
         }
     }
 
@@ -172,6 +188,13 @@ pub trait PlotItem {
             PlotGeometry::Points(points) => points,
             PlotGeometry::None => {
                 panic!("If the PlotItem has no geometry, on_hover() must not be called")
+            }
+            PlotGeometry::PointsXY { xs, ys } => {
+                let x = xs[elem.index];
+                let y = ys[elem.index];
+                let value = PlotPoint { x, y };
+
+                &[value]
             }
             PlotGeometry::Rects => {
                 panic!("If the PlotItem is made of rects, it should implement on_hover()")
@@ -401,7 +424,9 @@ impl PlotItem for VLine {
 /// A series of values forming a path.
 pub struct Line<'a> {
     base: PlotItemBase,
-    pub(super) series: PlotPoints<'a>,
+    pub(super) columnar: Option<ColumnarSeries<'a>>,
+    pub(super) series: Option<PlotPoints<'a>>,
+
     pub(super) stroke: Stroke,
     pub(super) fill: Option<f32>,
     pub(super) fill_alpha: f32,
@@ -409,13 +434,34 @@ pub struct Line<'a> {
     pub(super) gradient_fill: bool,
     pub(super) style: LineStyle,
 }
+impl<'a> Line<'a> {
+    #[inline]
+    pub fn new_xy(name: impl Into<String>, xs: &'a [f64], ys: &'a [f64]) -> Self {
+        Self::from_series(name, ColumnarSeries::new(xs, ys))
+    }
+    #[inline]
+    pub fn from_series(name: impl Into<String>, series: ColumnarSeries<'a>) -> Self {
+        Self {
+            base: PlotItemBase::new(name.into()),
+            columnar: Some(series),
+            series: None,
+            stroke: Stroke::new(1.5, Color32::TRANSPARENT),
+            fill: None,
+            fill_alpha: DEFAULT_FILL_ALPHA,
+            gradient_color: None,
+            gradient_fill: false,
+            style: LineStyle::Solid,
+        }
+    }
+}
 
 impl<'a> Line<'a> {
     pub fn new(name: impl Into<String>, series: impl Into<PlotPoints<'a>>) -> Self {
         Self {
             base: PlotItemBase::new(name.into()),
-            series: series.into(),
-            stroke: Stroke::new(1.5, Color32::TRANSPARENT), // Note: a stroke of 1.0 (or less) can look bad on low-dpi-screens
+            columnar: None,
+            series: Some(series.into()),
+            stroke: Stroke::new(1.5, Color32::TRANSPARENT),
             fill: None,
             fill_alpha: DEFAULT_FILL_ALPHA,
             gradient_color: None,
@@ -497,6 +543,7 @@ impl PlotItem for Line<'_> {
     fn shapes(&self, _ui: &Ui, transform: &PlotTransform, shapes: &mut Vec<Shape>) {
         let Self {
             base,
+            columnar,
             series,
             stroke,
             fill,
@@ -504,6 +551,7 @@ impl PlotItem for Line<'_> {
             style,
             ..
         } = self;
+
         let mut fill = *fill;
 
         let mut final_stroke: PathStroke = (*stroke).into();
@@ -518,11 +566,24 @@ impl PlotItem for Line<'_> {
             final_stroke = PathStroke::new_uv(stroke.width, wrapped_callback.clone());
         }
 
-        let values_tf: Vec<_> = series
-            .points()
-            .iter()
-            .map(|v| transform.position_from_point(v))
-            .collect();
+        let mut values_tf: Vec<Pos2> = Vec::new();
+        if let Some(cs) = columnar {
+            let n = cs.len();
+            values_tf.reserve(n);
+            for i in 0..n {
+                let value = PlotPoint {
+                    x: cs.xs()[i],
+                    y: cs.ys()[i],
+                };
+                values_tf.push(transform.position_from_point(&value));
+            }
+        } else if let Some(series) = series {
+            values_tf = series
+                .points()
+                .iter()
+                .map(|v| transform.position_from_point(v))
+                .collect();
+        }
         let n_values = values_tf.len();
 
         // Fill the area between the line and a reference line, if required.
@@ -537,20 +598,20 @@ impl PlotItem for Line<'_> {
             let y = transform
                 .position_from_point(&PlotPoint::new(0.0, y_reference))
                 .y;
-            let mut fill_color = Rgba::from(stroke.color)
+            let mut fill_color: Color32 = Rgba::from(stroke.color)
                 .to_opaque()
                 .multiply(fill_alpha)
                 .into();
             let mut mesh = Mesh::default();
             let expected_intersections = 20;
-            mesh.reserve_triangles((n_values - 1) * 2);
+            mesh.reserve_triangles(n_values.saturating_sub(1) * 2);
             mesh.reserve_vertices(n_values * 2 + expected_intersections);
             values_tf.windows(2).for_each(|w| {
                 if *gradient_fill && self.gradient_color.is_some() {
                     fill_color = Rgba::from(self
                         .gradient_color
                         .clone()
-                        .expect("Could not find gradient color callback")(
+                        .expect("missing gradient color callback")(
                         transform.value_from_position(w[1]),
                     ))
                     .to_opaque()
@@ -570,16 +631,20 @@ impl PlotItem for Line<'_> {
                     mesh.add_triangle(i + 1, i + 2, i + 3);
                 }
             });
-            let last = values_tf[n_values - 1];
-            mesh.colored_vertex(last, fill_color);
-            mesh.colored_vertex(pos2(last.x, y), fill_color);
+            if let Some(&last) = values_tf.last() {
+                mesh.colored_vertex(last, fill_color);
+                mesh.colored_vertex(pos2(last.x, y), fill_color);
+            }
             shapes.push(Shape::Mesh(std::sync::Arc::new(mesh)));
         }
+
         style.style_line(values_tf, final_stroke, base.highlight, shapes);
     }
 
     fn initialize(&mut self, x_range: RangeInclusive<f64>) {
-        self.series.generate_points(x_range);
+        if let Some(series) = &mut self.series {
+            series.generate_points(x_range);
+        }
     }
 
     fn color(&self) -> Color32 {
@@ -595,11 +660,26 @@ impl PlotItem for Line<'_> {
     }
 
     fn geometry(&self) -> PlotGeometry<'_> {
-        PlotGeometry::Points(self.series.points())
+        if let Some(cs) = &self.columnar {
+            PlotGeometry::PointsXY {
+                xs: cs.xs(),
+                ys: cs.ys(),
+            }
+        } else if let Some(series) = &self.series {
+            PlotGeometry::Points(series.points())
+        } else {
+            PlotGeometry::None
+        }
     }
 
     fn bounds(&self) -> PlotBounds {
-        self.series.bounds()
+        if let Some(cs) = &self.columnar {
+            cs.bounds()
+        } else if let Some(series) = &self.series {
+            series.bounds()
+        } else {
+            PlotBounds::NOTHING
+        }
     }
 }
 

--- a/egui_plot/src/lib.rs
+++ b/egui_plot/src/lib.rs
@@ -7,7 +7,7 @@
 //! ## Feature flags
 #![cfg_attr(feature = "document-features", doc = document_features::document_features!())]
 //!
-
+#![allow(deprecated)]
 mod axis;
 mod items;
 mod legend;
@@ -1874,7 +1874,7 @@ impl PreparedPlot<'_> {
                 "",
                 &plot,
                 &mut cursors,
-                label_formatter, 
+                label_formatter,
             );
             None
         };

--- a/egui_plot/src/plot_ui.rs
+++ b/egui_plot/src/plot_ui.rs
@@ -156,14 +156,10 @@ impl<'a> PlotUi<'a> {
 
     /// Add a data line.
     pub fn line(&mut self, mut line: crate::Line<'a>) {
-        if line.series.is_empty() {
-            return;
-        };
-
-        // Give the stroke an automatic color if no color has been assigned.
         if line.stroke.color == Color32::TRANSPARENT {
             line.stroke.color = self.auto_color();
         }
+
         self.items.push(Box::new(line));
     }
 

--- a/examples/borrow_points/src/main.rs
+++ b/examples/borrow_points/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![allow(rustdoc::missing_crate_level_docs)] // it's an example
+#![allow(deprecated)]
 
 use eframe::egui;
 use egui_plot::{Legend, Line, Plot, PlotPoint, PlotPoints};

--- a/examples/columnar/Cargo.toml
+++ b/examples/columnar/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "columnar"
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+eframe = { workspace = true, features = ["default"] }
+egui_plot.workspace = true
+[lints]
+workspace = true

--- a/examples/columnar/src/main.rs
+++ b/examples/columnar/src/main.rs
@@ -1,0 +1,55 @@
+use eframe::egui;
+use eframe::{App, Frame};
+use egui::{Color32, Context};
+use egui_plot::{Line, Plot, TooltipOptions};
+
+fn main() -> eframe::Result<()> {
+    eframe::run_native(
+        "Line::new_xy demo",
+        eframe::NativeOptions::default(),
+        Box::new(|_| Ok(Box::new(Demo::new()))),
+    )
+}
+
+struct Demo {
+    xs: Vec<f64>,
+    f1: Vec<f64>,
+    f2: Vec<f64>,
+}
+
+impl Demo {
+    fn new() -> Self {
+        let n = 500;
+        let xs: Vec<f64> = (0..n).map(|i| i as f64 * 0.02).collect();
+        let f1: Vec<f64> = xs.iter().map(|&t| t.sin()).collect();
+        let f2: Vec<f64> = xs
+            .iter()
+            .map(|&t| (t * 0.6 + 0.8).sin() * 0.8 + 0.2)
+            .collect();
+
+        Self { xs, f1, f2 }
+    }
+}
+
+impl App for Demo {
+    fn update(&mut self, ctx: &Context, _frame: &mut Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Columnar Line::new_xy API");
+
+            Plot::new("demo_plot").show(ui, |plot_ui| {
+                plot_ui.line(
+                    Line::new_xy("f1", &self.xs, &self.f1)
+                        .color(Color32::from_rgb(200, 100, 100))
+                        .width(2.0),
+                );
+                plot_ui.line(
+                    Line::new_xy("f2", &self.xs, &self.f2)
+                        .color(Color32::from_rgb(100, 160, 240))
+                        .width(2.0),
+                );
+
+                plot_ui.show_tooltip_with_options(&TooltipOptions::default());
+            });
+        });
+    }
+}

--- a/examples/custom_tooltip/src/main.rs
+++ b/examples/custom_tooltip/src/main.rs
@@ -1,4 +1,6 @@
 #![allow(rustdoc::missing_crate_level_docs)]
+#![allow(deprecated)]
+
 use std::f64::consts::PI;
 
 use eframe::egui::{self, RichText};


### PR DESCRIPTION
The PR introduces new columnar data representation for time series.

The goal is to reduce mem usage by avoiding PlotPoint allloc.

**New Features**
- ColumnarSeries<'a> : standalone type for storing &[f64@ slices for xs & ys. We provide .iter() to return (x,y) without alloc.
- Line::new_xy : A way to directly build line from columnar
- Deprecation of PlotPoint